### PR TITLE
Use an arbitrary version for the base image

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -6,27 +6,5 @@ RUN rm -rf ${CATALINA_HOME}/webapps/* \
     && mkdir ${CATALINA_HOME}/webapps/ROOT \
     && echo "<% response.sendRedirect(\"spoon\"); %>" > ${CATALINA_HOME}/webapps/ROOT/index.jsp
 
-
-# simple-jndi
-# LICENSE.txt
-# system/
-RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-static/$dist/pdi-static-$dist.zip && \
-  unzip -q pdi-static-$dist.zip system/* simple-jndi/* LICENSE.txt && \
-  mv LICENSE.txt webSpoon-LICENSE.txt && \
-  rm pdi-static-$dist.zip
-
-# system/karaf
-RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/pentaho/pentaho-karaf-assembly/$dist/pentaho-karaf-assembly-$dist-client.zip && \
-  unzip -q pentaho-karaf-assembly-$dist-client.zip && \
-  mv pentaho-karaf-assembly system/karaf && \
-  rm pentaho-karaf-assembly-$dist-client.zip
-
-# plugins
-RUN wget -q https://nexus.pentaho.org/repository/omni/org/pentaho/di/pdi-plugins/$dist/pdi-plugins-$dist.zip && \
-  unzip -q pdi-plugins-$dist.zip && \
-  rm pdi-plugins-$dist.zip
-
-# samples
-RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-samples/$dist/pdi-samples-$dist.zip && \
-  unzip -q pdi-samples-$dist.zip && \
-  rm pdi-samples-$dist.zip
+COPY install-base.sh /tmp/install-base.sh
+RUN sh /tmp/install-base.sh

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,16 +1,32 @@
 FROM tomcat:jre8
 MAINTAINER Hiromu Hota <hiromu.hota@hal.hitachi.com>
+ARG dist=8.2.0.0-342
 RUN rm /etc/java-8-openjdk/accessibility.properties
 RUN rm -rf ${CATALINA_HOME}/webapps/* \
     && mkdir ${CATALINA_HOME}/webapps/ROOT \
     && echo "<% response.sendRedirect(\"spoon\"); %>" > ${CATALINA_HOME}/webapps/ROOT/index.jsp
 
-RUN wget https://sourceforge.net/projects/pentaho/files/Pentaho%208.2/client-tools/pdi-ce-8.2.0.0-342.zip && \
-  unzip pdi-ce-8.2.0.0-342.zip && \
-  mv data-integration/system ${CATALINA_HOME}/system && \
-  mv data-integration/plugins ${CATALINA_HOME}/plugins && \
-  mv data-integration/simple-jndi ${CATALINA_HOME}/simple-jndi && \
-  mv data-integration/samples ${CATALINA_HOME}/samples && \
-  mv data-integration/LICENSE.txt ${CATALINA_HOME}/webSpoon-LICENSE.txt && \
-  rm pdi-ce-8.2.0.0-342.zip && \
-  rm -rf data-integration
+
+# simple-jndi
+# LICENSE.txt
+# system/
+RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-static/$dist/pdi-static-$dist.zip && \
+  unzip -q pdi-static-$dist.zip system/* simple-jndi/* LICENSE.txt && \
+  mv LICENSE.txt webSpoon-LICENSE.txt && \
+  rm pdi-static-$dist.zip
+
+# system/karaf
+RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/pentaho/pentaho-karaf-assembly/$dist/pentaho-karaf-assembly-$dist-client.zip && \
+  unzip -q pentaho-karaf-assembly-$dist-client.zip && \
+  mv pentaho-karaf-assembly system/karaf && \
+  rm pentaho-karaf-assembly-$dist-client.zip
+
+# plugins
+RUN wget -q https://nexus.pentaho.org/repository/omni/org/pentaho/di/pdi-plugins/$dist/pdi-plugins-$dist.zip && \
+  unzip -q pdi-plugins-$dist.zip && \
+  rm pdi-plugins-$dist.zip
+
+# samples
+RUN wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-samples/$dist/pdi-samples-$dist.zip && \
+  unzip -q pdi-samples-$dist.zip && \
+  rm pdi-samples-$dist.zip

--- a/install-base.sh
+++ b/install-base.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if [ -z ${dist} ]; then echo "dist is unset" && exit 1; fi
+
+# simple-jndi
+# LICENSE.txt
+# system/
+wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-static/$dist/pdi-static-$dist.zip || exit $?
+unzip -q pdi-static-$dist.zip system/* simple-jndi/* LICENSE.txt
+mv LICENSE.txt webSpoon-LICENSE.txt
+rm pdi-static-$dist.zip
+
+echo 'system/karaf'
+wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/pentaho/pentaho-karaf-assembly/$dist/pentaho-karaf-assembly-$dist-client.zip || exit $?
+unzip -q pentaho-karaf-assembly-$dist-client.zip
+mv pentaho-karaf-assembly system/karaf
+rm pentaho-karaf-assembly-$dist-client.zip
+
+echo 'plugins'
+wget -q https://nexus.pentaho.org/repository/omni/org/pentaho/di/pdi-plugins/$dist/pdi-plugins-$dist.zip || exit $?
+unzip -q pdi-plugins-$dist.zip
+rm pdi-plugins-$dist.zip
+
+echo 'samples'
+wget -q https://nexus.pentaho.org/repository/proxy-pentaho-public-release-group/org/pentaho/di/pdi-samples/$dist/pdi-samples-$dist.zip || exit $?
+unzip -q pdi-samples-$dist.zip
+rm pdi-samples-$dist.zip


### PR DESCRIPTION
So far, webSpoon has been relying on the first release of each major.minor version such as `8.1.0.0-365` for 8.1 and `8.2.0.0-342` for 8.2.
The reason for that is the whole packaged distribution is publicly available for only these versions, i.e., the community edition.

Meanwhile, pdi as of the first release tends to have many bugs and becomes stable in later patch releases like `8.2.0.3-XXX` for 8.2.
The motivation of this pull-request is to use an arbitrary version like `8.2.0.3-515` for the base image so that webSpoon can also benefit from these patches.