### PR TITLE
add k8s customization with PersistentVolumeClaims / ConfigMap

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,16 +28,16 @@ While port forwarding, access to the port of local machine.
 http://localhost:8080
 ```
 
-# Shared `.kettle` and `.pentaho` directory
+# Shared `~/.kettle` and `~/.pentaho` directory
 
-Pods share `.kettle` and `.pentaho` directory as PersistentVolumeClaim (PVC).
-If you want to deploy these PVCs to a Kubernetes cluster with multiple nodes, you can configure YAML files so that they can be shared among multiple nodes.
+Pods share `~/.kettle` and `~/.pentaho` directory as PersistentVolumeClaim (PVC).
+If you want to deploy these PVCs to a Kubernetes cluster which only supports `ReadWriteOnce`, you can configure YAML files.
 
 Edit `kettle-pvc.yaml` and `pentaho-pvc.yaml`.
 
 ```yaml
-  # - ReadWriteOnce # Comment out
-  - ReadWriteMany # Uncomment
+  # - ReadWriteMany # Comment out
+  - ReadWriteOnce # Uncomment
 ```
 
 # Customize

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -28,3 +28,55 @@ While port forwarding, access to the port of local machine.
 http://localhost:8080
 ```
 
+# Shared `.kettle` and `.pentaho` directory
+
+Pods share `.kettle` and `.pentaho` directory as PersistentVolumeClaim (PVC).
+If you want to deploy these PVCs to a Kubernetes cluster with multiple nodes, you can configure YAML files so that they can be shared among multiple nodes.
+
+Edit `kettle-pvc.yaml` and `pentaho-pvc.yaml`.
+
+```yaml
+  # - ReadWriteOnce # Comment out
+  - ReadWriteMany # Uncomment
+```
+
+# Customize
+
+## Add `web.xml` etc.
+
+Create your own `web.xml` file and run this command to make ConfigMap including the `web.xml`.
+
+```sh
+$ kubectl create configmap webspoon-config-cm --from-file web.xml
+```
+
+Then, edit `deployment.yaml` and uncomment this section to mount ConfigMap to containers.
+
+```yaml
+        volumeMounts:
+        ...
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/web.xml
+        #   name: webspoon-config-cm
+        #   subPath: web.xml
+        ...
+      volumes:
+      # - name: webspoon-config-cm
+      #   configMap:
+      #     name: webspoon-config-cm
+```
+
+File locations by default
+
+| File | Mount target in webSpoon pod |
+|-|-|
+| `web.xml` | `/usr/local/tomcat/webapps/spoon/WEB-INF/web.xml` |
+| `catalina.policy` | `/usr/local/tomcat/conf/catalina.policy` |
+| `security.xml` | `/usr/local/tomcat/webapps/spoon/WEB-INF/spring/security.xml`|
+
+# Tear down
+
+```sh
+$ kubectl delete -f ./k8s
+# If you created ConfigMap
+$ kubectl delete configmap webspoon-config-cm
+```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -28,6 +28,32 @@ spec:
         ports:
         - containerPort: 8080
         resources: {}
+        volumeMounts:
+        - mountPath: /home/tomcat/.kettle
+          name: kettle-pvc
+        - mountPath: /home/tomcat/.pentaho
+          name: pentaho-pvc
+        # # When you created your own config file, uncomment each section depending on file.
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/web.xml
+        #   name: webspoon-config-cm
+        #   subPath: web.xml
+        # - mountPath: /usr/local/tomcat/conf/catalina.policy
+        #   name: webspoon-config-cm
+        #   subPath: catalina.policy
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/spring/security.xml
+        #   name: webspoon-config-cm
+        #   subPath: security.xml
       restartPolicy: Always
       serviceAccountName: ""
+      volumes:
+      - name: kettle-pvc
+        persistentVolumeClaim:
+          claimName: kettle-pvc
+      - name: pentaho-pvc
+        persistentVolumeClaim:
+          claimName: pentaho-pvc
+      # # Uncomment to mount ConfigMap if you created ConfigMap
+      # - name: webspoon-config-cm
+      #   configMap:
+      #     name: webspoon-config-cm
 status: {}

--- a/k8s/kettle-pvc.yaml
+++ b/k8s/kettle-pvc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: kettle-pvc
 spec:
   accessModes:
-  - ReadWriteOnce
-  # - ReadWriteMany
+  - ReadWriteMany
+  # - ReadWriteOnce
   resources:
     requests:
       storage: 100Mi

--- a/k8s/kettle-pvc.yaml
+++ b/k8s/kettle-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kettle-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  # - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi

--- a/k8s/pentaho-pvc.yaml
+++ b/k8s/pentaho-pvc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: pentaho-pvc
 spec:
   accessModes:
-  - ReadWriteOnce
-  # - ReadWriteMany
+  - ReadWriteMany
+  # - ReadWriteOnce
   resources:
     requests:
       storage: 100Mi

--- a/k8s/pentaho-pvc.yaml
+++ b/k8s/pentaho-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pentaho-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  # - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
This PR enhances Kubernetes resource files at these points

- Share both `.kettle` and `.pentaho` files among Pods as PersistentVolumeClaims.
- Customize `web.xml` etc. as ConfigMap
- Add how to tear down to README.md

ToDos (another PR)
- Helm chart